### PR TITLE
Handle tags in a stream rather than loading the entire page before parsing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Logs
 logs
 *.log

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = function discoverRelPaymentUrl(url, { allowHttp = false } = {})
       (res.headers.link || '').split(/,\s*/).forEach(link => {
         const parsed = parseLinkHeader(link);
 
-        if (parsed.payment) {
+        if (parsed && parsed.payment) {
           paymentUrls.fromLinkHeaders.push({
             uri: urlResolve(url, parsed.payment.url),
             title: parsed.payment.title

--- a/index.js
+++ b/index.js
@@ -1,63 +1,78 @@
 'use strict';
 
-const fetch = require('node-fetch');
-const cheerio = require('cheerio');
+const http = require('http');
+const https = require('https');
+const parse5 = require('parse5');
 const parseLinkHeader = require('parse-link-header');
 const { resolve: urlResolve } = require('url');
 
-module.exports = async function discoverRelPaymentUrl(url, { allowHttp = false } = {}) {
+function attributesArrayToObject(attributesArray) {
+  const attributesObject = {};
+
+  for (const { name, value } of attributesArray) {
+    attributesObject[name] = value;
+  }
+
+  return attributesObject;
+}
+
+module.exports = function discoverRelPaymentUrl(url, { allowHttp = false } = {}) {
   const paymentUrls = {
     fromLinkHeaders: [],
     fromAnchors: [],
     fromLinks: []
   };
 
-  if (!allowHttp && !url.startsWith('https://')) {
-    return paymentUrls;
+  let get;
+
+  if (url.startsWith('https://')) {
+    get = https.get;
+  } else if (allowHttp) {
+    get = http.get;
+  } else {
+    return Promise.resolve(paymentUrls);
   }
 
-  // TODO: Should throws be handled here?
-  const res = await fetch(url);
+  return new Promise((resolve, reject) => {
+    if (!allowHttp && !url.startsWith('https://')) {
+      return resolve(paymentUrls);
+    }
 
-  (res.headers.get('link') || '').split(/,\s*/).forEach(link => {
-    const parsed = parseLinkHeader(link);
+    const parse = new parse5.SAXParser();
 
-    if (parsed.payment) {
-      paymentUrls.fromLinkHeaders.push({
-        uri: urlResolve(url, parsed.payment.url),
-        title: parsed.payment.title
+    parse.on('startTag', (name, attributesArray) => {
+      if (name !== 'link' && name !== 'a') {
+        return;
+      }
+
+      const { rel, title, href } = attributesArrayToObject(attributesArray);
+
+      if (rel === 'payment' && href) {
+        const uri = urlResolve(url, href);
+
+        if (name === 'link') {
+          paymentUrls.fromLinks.push({ uri, title });
+        } else {
+          paymentUrls.fromAnchors.push({ uri, title });
+        }
+      }
+    });
+
+    get(url, res => {
+      (res.headers.link || '').split(/,\s*/).forEach(link => {
+        const parsed = parseLinkHeader(link);
+
+        if (parsed.payment) {
+          paymentUrls.fromLinkHeaders.push({
+            uri: urlResolve(url, parsed.payment.url),
+            title: parsed.payment.title
+          });
+        }
       });
-    }
+
+      res.pipe(parse).once('end', () => resolve(paymentUrls));
+      parse.once('error', reject);
+      res.once('error', reject);
+    }).on('error', reject);
   });
-
-  const body = await res.text();
-  const $ = cheerio.load(body);
-
-  $('a').each((i, el) => {
-    const $el = $(el);
-
-    if ($el.attr('rel') === 'payment') {
-      const href = $el.attr('href');
-      const title = $el.attr('title') || $el.text().trim();
-
-      if (href) {
-        paymentUrls.fromAnchors.push({ uri: urlResolve(url, href), title });
-      }
-    }
-  });
-
-  $('link').each((i, el) => {
-    const $el = $(el);
-
-    if ($el.attr('rel') === 'payment') {
-      const href = $el.attr('href');
-      const title = $el.attr('title');
-
-      if (href) {
-        paymentUrls.fromLinks.push({ uri: urlResolve(url, href), title });
-      }
-    }
-  });
-
-  return paymentUrls;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/node": {
-      "version": "4.0.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-4.0.36.tgz",
-      "integrity": "sha512-mREYlo/xzYykqXNQm5jJ9w3p/lVi85OXj8bECy5N0AjP63BOrmaSwFLgxDkp7OCljLNoT6LWXFAFotPwilNTRw=="
-    },
     "acorn": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
@@ -123,11 +118,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
-    },
     "brace-expansion": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.9.tgz",
@@ -187,19 +177,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
-    },
-    "cheerio": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
-      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
-      "requires": {
-        "css-select": "1.2.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.9.2",
-        "lodash": "4.17.5",
-        "parse5": "3.0.3"
-      }
     },
     "circular-json": {
       "version": "0.3.3",
@@ -272,22 +249,6 @@
         "which": "1.3.0"
       }
     },
-    "css-select": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
-        "domutils": "1.5.1",
-        "nth-check": "1.0.1"
-      }
-    },
-    "css-what": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
-    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -327,49 +288,6 @@
       "requires": {
         "esutils": "2.0.2"
       }
-    },
-    "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-      "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
-        }
-      }
-    },
-    "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
-    },
-    "domhandler": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
-      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
-      "requires": {
-        "domelementtype": "1.3.0"
-      }
-    },
-    "domutils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
-      }
-    },
-    "entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -602,19 +520,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
-    "htmlparser2": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
-      "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.1",
-        "domutils": "1.5.1",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
-      }
-    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -829,15 +734,8 @@
     "node-fetch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.0.0.tgz",
-      "integrity": "sha1-mCu6Q+zU8pIqKcwYamu7C7c/y6Y="
-    },
-    "nth-check": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-      "requires": {
-        "boolbase": "1.0.0"
-      }
+      "integrity": "sha1-mCu6Q+zU8pIqKcwYamu7C7c/y6Y=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -887,12 +785,9 @@
       }
     },
     "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "requires": {
-        "@types/node": "4.0.36"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
     },
     "path-is-absolute": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Discover a rel=\"payment\" donations URL given a URL for the containing page. ",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_EXTRA_CA_CERTS=./test/safe-keypair/localCA.cert mocha --recursive test",
+    "test": "NODE_EXTRA_CA_CERTS=./test/safe-keypair/local.cert mocha --recursive test",
     "lint": "eslint ."
   },
   "repository": {
@@ -24,12 +24,13 @@
   },
   "homepage": "https://github.com/qubyte/rel-payment#readme",
   "dependencies": {
-    "cheerio": "^1.0.0-rc.2",
     "eslint": "^4.17.0",
     "eslint-config-qubyte": "^1.1.0",
     "mocha": "^5.0.0",
-    "node-fetch": "^2.0.0",
-    "parse-link-header": "^1.0.1"
+    "parse-link-header": "^1.0.1",
+    "parse5": "^4.0.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "node-fetch": "^2.0.0"
+  }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,6 @@ const http = require('http');
 const https = require('https');
 const { join: pathJoin } = require('path');
 const { readFileSync } = require('fs');
-const fetch = require('node-fetch');
 const relPayment = require('..');
 
 const safeKey = readFileSync(pathJoin(__dirname, 'safe-keypair', 'local.key'));
@@ -99,7 +98,26 @@ describe('rel-payment', () => {
       ],
       fromAnchors: [
         { uri: 'https://example.com/payment-in-anchor-a', title: 'title-a' },
-        { uri: 'https://example.com/payment-in-anchor-b', title: 'Payment Anchor' }
+        { uri: 'https://example.com/payment-in-anchor-b', title: undefined }
+      ],
+      fromLinks: [
+        { uri: 'https://example.com/payment-in-link-a', title: 'title-a' },
+        { uri: 'https://example.com/payment-in-link-b', title: 'title-b' }
+      ]
+    });
+  });
+
+  it.skip('returns payment URLs for HTTPS URLs', async () => {
+    const urls = await relPayment(`https://localhost:${safeHttpsPort}/headers-anchors-links`);
+
+    assert.deepEqual(urls, {
+      fromLinkHeaders: [
+        { uri: 'https://example.com/payment-in-header-a', title: 'title-a' },
+        { uri: 'https://example.com/payment-in-header-b', title: 'title-b' }
+      ],
+      fromAnchors: [
+        { uri: 'https://example.com/payment-in-anchor-a', title: 'title-a' },
+        { uri: 'https://example.com/payment-in-anchor-b', title: undefined }
       ],
       fromLinks: [
         { uri: 'https://example.com/payment-in-link-a', title: 'title-a' },
@@ -112,7 +130,6 @@ describe('rel-payment', () => {
     try {
       await relPayment(`https://localhost:${unsafeHttpsPort}/headers-anchors-links`);
     } catch (e) {
-      assert.ok(e instanceof fetch.FetchError);
       return;
     }
 


### PR DESCRIPTION
Note: HTTPS tests are still broken.

This PR swaps out cheerio for the underlying parse5 library, which provides a streaming parser which is sensitive to opening tags.