### PR TITLE
Drop parse-link-header as a dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v4.1.0
+
+- Adds support for grabbing the
+  [title](https://datatracker.ietf.org/doc/html/rfc8288#section-3.4.1) as an
+  [extended attribute](https://datatracker.ietf.org/doc/html/rfc8187#section-3.2.1)
+  from headers.
+- Lessens the node_modules footprint a little.
+
 ## v4.0.0
 
 - Drops support for Node 12.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
+        "http-link-header": "^1.0.5",
         "node-fetch": "^3.2.6",
-        "parse-link-header": "^2.0.0",
         "parse5-sax-parser": "^7.0.0"
       },
       "devDependencies": {
@@ -19,7 +19,7 @@
         "mocha": "^9.2.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -842,6 +842,14 @@
         "he": "bin/he"
       }
     },
+    "node_modules/http-link-header": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.5.tgz",
+      "integrity": "sha512-msKrMbv/xHzhdOD4sstbEr+NbGqpv8ZtZliiCeByGENJo1jK1GZ/81zHF9HpWtEH5ihovPpdqHXniwZapJCKEA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -1268,14 +1276,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-link-header": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
-      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
-      "dependencies": {
-        "xtend": "~4.0.1"
-      }
-    },
     "node_modules/parse5": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
@@ -1638,14 +1638,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -2312,6 +2304,11 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "http-link-header": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.5.tgz",
+      "integrity": "sha512-msKrMbv/xHzhdOD4sstbEr+NbGqpv8ZtZliiCeByGENJo1jK1GZ/81zHF9HpWtEH5ihovPpdqHXniwZapJCKEA=="
+    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -2616,14 +2613,6 @@
         "callsites": "^3.0.0"
       }
     },
-    "parse-link-header": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
-      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
-      "requires": {
-        "xtend": "~4.0.1"
-      }
-    },
     "parse5": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
@@ -2873,11 +2862,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "author": "Mark Stanley Everitt",
   "license": "MIT",
   "dependencies": {
+    "http-link-header": "^1.0.5",
     "node-fetch": "^3.2.6",
-    "parse-link-header": "^2.0.0",
     "parse5-sax-parser": "^7.0.0"
   },
   "devDependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,8 +20,11 @@ function handleRequest(req, res) {
     res.writeHead(200, {
       'Content-Type': 'text/html',
       Link: [
-        '<https://example.com/payment-in-header-a>; rel="payment"; title="title-a"',
-        '<https://example.com/payment-in-header-b>; rel="payment"; title="title-b"'
+        '<https://example.com/payment-in-header-simple>; rel="payment"; title="title-a"',
+        '<https://example.com/payment-in-header-unquoted-rel>; rel=payment; title="title-b"',
+        '<https://example.com/payment-in-header-extended-attribute-title>; rel="payment"; title*="UTF-8\'en\'%74%69%74%6C%65%2D%63"',
+        '</path-part-in-header-only>; rel="payment"; title="title-d"',
+        '<https://example.com/payment-in-header-extended-attribute-title-fallback-undecodable>; rel="payment"; title="title-e"; title*="BLAH\'\'%74%69%74%6C%65%2D%63"' // eslint-disable-line max-len
       ].join(', ')
     });
     res.end(`
@@ -116,8 +119,11 @@ describe('rel-payment', () => {
 
     assert.deepStrictEqual(urls, {
       fromLinkHeaders: [
-        { url: new URL('https://example.com/payment-in-header-a'), title: 'title-a' },
-        { url: new URL('https://example.com/payment-in-header-b'), title: 'title-b' }
+        { url: new URL('https://example.com/payment-in-header-simple'), title: 'title-a' },
+        { url: new URL('https://example.com/payment-in-header-unquoted-rel'), title: 'title-b' },
+        { url: new URL('https://example.com/payment-in-header-extended-attribute-title'), title: 'title-c' },
+        { url: new URL('http://localhost:3000/path-part-in-header-only'), title: 'title-d' },
+        { url: new URL('https://example.com/payment-in-header-extended-attribute-title-fallback-undecodable'), title: 'title-e' }
       ],
       fromAnchors: [
         { url: new URL('https://example.com/payment-in-anchor-a'), title: 'title-a' },
@@ -136,8 +142,11 @@ describe('rel-payment', () => {
 
     assert.deepStrictEqual(urls, {
       fromLinkHeaders: [
-        { url: new URL('https://example.com/payment-in-header-a'), title: 'title-a' },
-        { url: new URL('https://example.com/payment-in-header-b'), title: 'title-b' }
+        { url: new URL('https://example.com/payment-in-header-simple'), title: 'title-a' },
+        { url: new URL('https://example.com/payment-in-header-unquoted-rel'), title: 'title-b' },
+        { url: new URL('https://example.com/payment-in-header-extended-attribute-title'), title: 'title-c' },
+        { url: new URL('http://localhost:3000/path-part-in-header-only'), title: 'title-d' },
+        { url: new URL('https://example.com/payment-in-header-extended-attribute-title-fallback-undecodable'), title: 'title-e' }
       ],
       fromAnchors: [
         { url: new URL('https://example.com/payment-in-anchor-a'), title: 'title-a' },
@@ -155,8 +164,11 @@ describe('rel-payment', () => {
 
     assert.deepStrictEqual(urls, {
       fromLinkHeaders: [
-        { url: new URL('https://example.com/payment-in-header-a'), title: 'title-a' },
-        { url: new URL('https://example.com/payment-in-header-b'), title: 'title-b' }
+        { url: new URL('https://example.com/payment-in-header-simple'), title: 'title-a' },
+        { url: new URL('https://example.com/payment-in-header-unquoted-rel'), title: 'title-b' },
+        { url: new URL('https://example.com/payment-in-header-extended-attribute-title'), title: 'title-c' },
+        { url: new URL('http://localhost:3000/path-part-in-header-only'), title: 'title-d' },
+        { url: new URL('https://example.com/payment-in-header-extended-attribute-title-fallback-undecodable'), title: 'title-e' }
       ],
       fromAnchors: [
         { url: new URL('https://example.com/payment-in-anchor-a'), title: 'title-a' },


### PR DESCRIPTION
Replace parse-link-header for a more comprehensive link header parser with a smaller node_modules footprint.