### PR TITLE
Avoid packaging unnecessary files in the published package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "engines": {
     "node": ">=14"
   },
+  "files": [],
   "repository": "github:qubyte/rel-payment",
   "keywords": [
     "payment",


### PR DESCRIPTION
Versions published after merging this PR will contain only files necessary for production use.

Before:
- 18 files
- 14.0 kB (packed)
- 28.9 kB (unpacked)

After:
- 4 files
- 2.6 kB (packed)
- 5.2 kB (unpacked)