### PR TITLE
Fix ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export = discoverRelPaymentUrl;
+export default discoverRelPaymentUrl;
 
 declare function discoverRelPaymentUrl(
   url: URL | string,

--- a/index.js
+++ b/index.js
@@ -69,6 +69,10 @@ export default async function discoverRelPaymentUrl(url, { allowHttp = false } =
     .rel('payment')
     .map(rel => ({ url: new URL(rel.uri, targetUrl), title: pickTitle(rel) }));
 
+  if (!res.body) {
+    return paymentUrls;
+  }
+
   res.body.setEncoding('utf8');
 
   await pipeline(res.body, parse);

--- a/index.js
+++ b/index.js
@@ -6,16 +6,6 @@ import { pipeline as pipelinecb } from 'stream';
 
 const pipeline = promisify(pipelinecb);
 
-function attributesArrayToObject(attributesArray) {
-  const attributesObject = {};
-
-  for (const { name, value } of attributesArray) {
-    attributesObject[name] = value;
-  }
-
-  return attributesObject;
-}
-
 // Support extended attributes when they're successfully decoded by LinkHeader.
 // Otherwise fall back to the title attribute. A null encoding indicates the
 // header was properly decoded.
@@ -49,7 +39,7 @@ export default async function discoverRelPaymentUrl(url, { allowHttp = false } =
       return;
     }
 
-    const { rel, title = '', href } = attributesArrayToObject(attrs);
+    const { rel, title = '', href } = Object.fromEntries(attrs.map(({ name, value }) => [name, value]));
 
     if (rel === 'payment' && href) {
       const url = new URL(href, targetUrl);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.1.1",
   "description": "Discover a rel=\"payment\" donations URL given a URL for the containing page. ",
   "main": "index.js",
+  "types": "./index.d.ts",
   "type": "module",
   "exports": {
     ".": "./index.js"
@@ -14,7 +15,7 @@
   "engines": {
     "node": ">=14"
   },
-  "files": [],
+  "files": ["index.d.ts"],
   "repository": "github:qubyte/rel-payment",
   "keywords": [
     "payment",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,6 +16,10 @@ function handleRequest(req, res) {
     res.end('<!doctype html><html></html>');
     return;
 
+  case '/no-body':
+    res.writeHead(204).end();
+    return;
+
   case '/headers-anchors-links':
     res.writeHead(200, {
       'Content-Type': 'text/html',
@@ -112,6 +116,10 @@ describe('rel-payment', () => {
     }
 
     throw new Error('Should have thrown');
+  });
+
+  it('does not throw when a request for a target responds with no body', async () => {
+    await relPayment(`http://localhost:${httpPort}/no-body`, { allowHttp: true });
   });
 
   it('returns payment URLs for HTTP string URLs when configured to', async () => {


### PR DESCRIPTION
I inadvertantly dropped the TS declaration file from the published package, but it turns out it was slightly broken anyway by the migration to ES modules. This PR fixes both.

It also handles handling for `null` response bodies from `fetch`. This doesn't seem to occur with node-fetch, but it _does_ look like it can happen in the spec. This change ensures that this library continues to work should node-fetch start producing `null` response bodies.